### PR TITLE
Add `metadata/1` to `Klife.Broker` 

### DIFF
--- a/lib/klife/connection/broker.ex
+++ b/lib/klife/connection/broker.ex
@@ -7,9 +7,12 @@ defmodule Klife.Connection.Broker do
 
   require Logger
 
+  alias KlifeProtocol.Messages
+
   alias Klife.Connection
   alias Klife.Connection.Controller
   alias Klife.Connection.MessageVersions
+
 
   @reconnect_delays_seconds [1, 1, 1, 1, 5, 5, 10]
 
@@ -174,6 +177,11 @@ defmodule Klife.Connection.Broker do
     end
   end
 
+  def metadata(client_name) do
+    content = %{topics: nil}
+    send_message(Messages.Metadata, client_name, :controller, content)
+  end
+
   defp reply_message(<<correlation_id::32-signed, _rest::binary>> = reply, client_name, conn) do
     case Controller.take_from_in_flight(client_name, correlation_id) do
       # sync send
@@ -239,7 +247,7 @@ defmodule Klife.Connection.Broker do
   defp get_broker_id(:any, client_name), do: Controller.get_random_broker_id(client_name)
 
   defp get_broker_id(:controller, client_name),
-    do: Controller.get_client_controller(client_name)
+    do: Controller.get_cluster_controller(client_name)
 
   defp get_broker_id(broker_id, _client_name), do: broker_id
 

--- a/lib/klife/connection/controller.ex
+++ b/lib/klife/connection/controller.ex
@@ -158,7 +158,7 @@ defmodule Klife.Connection.Controller do
   def handle_info(:check_cluster, %__MODULE__{} = state) do
     case get_cluster_info(state.bootstrap_conn) do
       {:ok, %{brokers: new_brokers_list, controller: controller}} ->
-        set_client_controller(controller, state.client_name)
+        set_cluster_controller(controller, state.client_name)
 
         old_brokers = state.known_brokers
         to_remove = old_brokers -- new_brokers_list
@@ -271,8 +271,8 @@ defmodule Klife.Connection.Controller do
     GenServer.cast(via_tuple({__MODULE__, client_name}), :trigger_check_cluster)
   end
 
-  def get_client_controller(client_name),
-    do: :persistent_term.get({:client_controller, client_name})
+  def get_cluster_controller(client_name),
+    do: :persistent_term.get({:cluster_controller, client_name})
 
   def get_known_brokers(client_name),
     do: :persistent_term.get({:known_brokers_ids, client_name})
@@ -389,8 +389,8 @@ defmodule Klife.Connection.Controller do
         """)
   end
 
-  defp set_client_controller(broker_id, client_name),
-    do: :persistent_term.put({:client_controller, client_name}, broker_id)
+  defp set_cluster_controller(broker_id, client_name),
+    do: :persistent_term.put({:cluster_controller, client_name}, broker_id)
 
   defp negotiate_api_versions(%Connection{} = conn, client_name) do
     :ok =

--- a/lib/klife/producer/controller.ex
+++ b/lib/klife/producer/controller.ex
@@ -7,7 +7,6 @@ defmodule Klife.Producer.Controller do
 
   alias Klife.PubSub
 
-  alias KlifeProtocol.Messages
   alias Klife.Connection.Broker
   alias Klife.Connection.Controller, as: ConnController
   alias Klife.Producer.ProducerSupervisor
@@ -88,9 +87,7 @@ defmodule Klife.Producer.Controller do
         :check_metadata,
         %__MODULE__{client_name: client_name} = state
       ) do
-    content = %{topics: nil}
-
-    case Broker.send_message(Messages.Metadata, client_name, :controller, content) do
+    case Broker.metadata(client_name) do
       {:error, _} ->
         :ok = ConnController.trigger_brokers_verification(client_name)
         new_ref = Process.send_after(self(), :check_metadata, :timer.seconds(1))


### PR DESCRIPTION
Expose a `metadata/1` function in `Klife.Connection.Broker` to get the cluster metadata.